### PR TITLE
Make default property value functionality the same as in the original datastore NDB.

### DIFF
--- a/ndb_orm/model.py
+++ b/ndb_orm/model.py
@@ -1312,7 +1312,7 @@ class Property(ModelAttribute):
     else:
       if value is not None:
         newvalue = function(value)
-        if newvalue is not None and newvalue is not value:
+        if newvalue is not None:
           self._store_value(entity, newvalue)
           value = newvalue
     return value


### PR DESCRIPTION
The original NDB behavior when using default parameter is passing the default value inside datastore even when initiating a Model without the relevant. Currently, that doesn't happen. The entity is being saved without the default value which means that you can't query on it and worst than that, if you'll change the default value in the application level it'll affect on retro actively inserted queries.

Python 2.7 NDB example code:
```
from google.appengine.ext import ndb

class DefaultTest(ndb.Model):
    myCounter = ndb.IntegerProperty(required=False, default=20)

example = DefaultTest(id=123)
example.put()
```

In python 2.7 this entity will be saved with myCounter=20 in datastore while in python 3.7 this entity will be saved as an empty (containing only a key, missing myCounter aka missing all default properties that wasn't set explicitly in the Model init).

Python 37 NDB example code:
```
    class DefaultTest(ndb.Model):
        myCounter = ndb.IntegerProperty(required=False, default=20)

    example = DefaultTest(id=123)
    client.put(example)
```

Can be checked easily with this code:

`client.get(client.key('DefaultTest', 123))['myCounter']`

Which will get an exception in the Python 3.7 DS while in the 2.7 DS it'll get the correct value. 